### PR TITLE
Add WRF-Chem Apptainer container definition files

### DIFF
--- a/.github/workflows/build-wrf-chem-docker.yml
+++ b/.github/workflows/build-wrf-chem-docker.yml
@@ -21,7 +21,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ghcr.io/${{ github.repository }}/wrf-chem  # ghcr.io/ncar/i-wrf/wrf-chem
+  # IMAGE is derived (lowercased) in the "Resolve image name" step below,
+  # because OCI registries reject uppercase characters in repository paths.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build:
@@ -52,6 +54,12 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Resolve image name (lowercase)
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          echo "IMAGE=ghcr.io/${REPO,,}/wrf-chem" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-wrf-chem-docker.yml
+++ b/.github/workflows/build-wrf-chem-docker.yml
@@ -53,7 +53,7 @@ jobs:
           df -h /
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve image name (lowercase)
         env:

--- a/.github/workflows/build-wrf-chem-docker.yml
+++ b/.github/workflows/build-wrf-chem-docker.yml
@@ -21,77 +21,129 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/wrf-chem  # ghcr.io/ncar/i-wrf/wrf-chem
+  IMAGE: ghcr.io/${{ github.repository }}/wrf-chem  # ghcr.io/ncar/i-wrf/wrf-chem
 
 jobs:
   build:
     name: Build and push WRF-Chem image
     runs-on: ubuntu-latest
-    timeout-minutes: 350  # Just under the 6-hour hard limit
+    timeout-minutes: 350
 
     permissions:
       contents: read
-      packages: write  # Needed to push to GHCR
+      packages: write
 
     steps:
-      # WRF-Chem builds routinely exceed the ~14 GB free on a default runner.
-      # This reclaims ~25 GB by removing preinstalled toolchains we don't use.
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
+        # WRF-Chem builds exceed the ~14 GB free on a default runner. Reclaim
+        # ~30 GB by removing preinstalled toolchains we don't use.
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/graalvm
+          sudo rm -rf /usr/local/.ghcup
+          sudo docker image prune --all --force || true
+          df -h /
 
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-      - name: Derive image tags and labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=match,pattern=wrf-chem-v(.*),group=1
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Derive image tags
+        id: tags
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHORT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          short_sha="${SHORT_SHA:0:7}"
+          tags=()
+          case "$EVENT_NAME" in
+            pull_request)
+              tags+=("${IMAGE}:pr-${PR_NUMBER}")
+              ;;
+            push)
+              if [[ "$REF_TYPE" == "tag" && "$REF_NAME" == wrf-chem-v* ]]; then
+                version="${REF_NAME#wrf-chem-v}"
+                tags+=("${IMAGE}:${version}" "${IMAGE}:latest")
+              elif [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+                tags+=("${IMAGE}:main" "${IMAGE}:latest")
+              else
+                tags+=("${IMAGE}:${REF_NAME//\//-}")
+              fi
+              tags+=("${IMAGE}:sha-${short_sha}")
+              ;;
+            workflow_dispatch)
+              tags+=("${IMAGE}:manual-${short_sha}")
+              ;;
+          esac
+          # Emit as --tag arguments, one per line, for xargs-style consumption.
+          {
+            echo 'tag_args<<EOF'
+            for t in "${tags[@]}"; do echo "--tag $t"; done
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo 'tags<<EOF'
+            for t in "${tags[@]}"; do echo "$t"; done
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ./docker/wrf-chem
-          file: ./docker/wrf-chem/Dockerfile
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.push_image) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=wrf-chem
-          cache-to: type=gha,scope=wrf-chem,mode=max
+      - name: Build (and optionally push) image
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          TAG_ARGS: ${{ steps.tags.outputs.tag_args }}
+          DO_PUSH: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.push_image) }}
+        run: |
+          set -euxo pipefail
+          # Registry-backed layer cache lives as a sibling tag in GHCR.
+          # mode=max caches all stages, including the expensive WRF/WPS build.
+          cache_ref="${IMAGE}:buildcache"
+          cache_from="--cache-from=type=registry,ref=${cache_ref}"
+          cache_to=""
+          push_flag=""
+          if [[ "$DO_PUSH" == "true" ]]; then
+            push_flag="--push"
+            cache_to="--cache-to=type=registry,ref=${cache_ref},mode=max"
+          fi
+          # Ensure a buildx builder exists (default on ubuntu-latest is docker,
+          # which doesn't support advanced cache backends).
+          docker buildx create --name wrf-builder --use --bootstrap || docker buildx use wrf-builder
+          # shellcheck disable=SC2086
+          docker buildx build \
+            --platform linux/amd64 \
+            $push_flag \
+            $cache_from \
+            $cache_to \
+            $TAG_ARGS \
+            --file docker/wrf-chem/Dockerfile \
+            docker/wrf-chem
 
-      - name: Image summary
+      - name: Build summary
         if: always()
         env:
-          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           {
             echo "### WRF-Chem image build"
             echo '```'
-            echo "$IMAGE_TAGS"
+            echo "$TAGS"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-wrf-chem-docker.yml
+++ b/.github/workflows/build-wrf-chem-docker.yml
@@ -1,0 +1,97 @@
+name: Build WRF-Chem Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/wrf-chem/**'
+      - '.github/workflows/build-wrf-chem-docker.yml'
+    tags:
+      - 'wrf-chem-v*'
+  pull_request:
+    paths:
+      - 'docker/wrf-chem/**'
+      - '.github/workflows/build-wrf-chem-docker.yml'
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to GHCR (otherwise build-only)'
+        type: boolean
+        default: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/wrf-chem  # ghcr.io/ncar/i-wrf/wrf-chem
+
+jobs:
+  build:
+    name: Build and push WRF-Chem image
+    runs-on: ubuntu-latest
+    timeout-minutes: 350  # Just under the 6-hour hard limit
+
+    permissions:
+      contents: read
+      packages: write  # Needed to push to GHCR
+
+    steps:
+      # WRF-Chem builds routinely exceed the ~14 GB free on a default runner.
+      # This reclaims ~25 GB by removing preinstalled toolchains we don't use.
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=wrf-chem-v(.*),group=1
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/wrf-chem
+          file: ./docker/wrf-chem/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.push_image) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=wrf-chem
+          cache-to: type=gha,scope=wrf-chem,mode=max
+
+      - name: Image summary
+        if: always()
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          {
+            echo "### WRF-Chem image build"
+            echo '```'
+            echo "$IMAGE_TAGS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/wrf-chem/Dockerfile
+++ b/docker/wrf-chem/Dockerfile
@@ -262,7 +262,7 @@ LABEL version="1.0"
 RUN dnf -y update && \
     dnf -y install epel-release && \
     dnf config-manager --set-enabled crb && \
-    dnf -y install \
+    dnf -y install --allowerasing \
         openmpi openmpi-devel \
         jasper-libs \
         libpng \

--- a/docker/wrf-chem/Dockerfile
+++ b/docker/wrf-chem/Dockerfile
@@ -1,0 +1,333 @@
+# WRF-Chem 4.7.1 + WPS 4.6.0 + Preprocessing Tools on AlmaLinux 9
+#
+# Docker equivalent of wrf-chem_full_almalinux9.def (single-layer Apptainer build).
+# Uses multi-stage build to reduce final image size.
+#
+# Build:
+#   docker build -t wrf-chem:4.7.1 .
+#
+# Run interactively:
+#   docker run --rm -it wrf-chem:4.7.1
+#
+# Run WRF with MPI:
+#   docker run --rm -it wrf-chem:4.7.1 mpirun -np 4 --allow-run-as-root wrf.exe
+
+# ==============================================================================
+# Stage 1: Build everything
+# ==============================================================================
+FROM almalinux:9 AS build
+
+LABEL maintainer="V. Weeks"
+LABEL description="WRF-Chem 4.7.1 with WPS 4.6.0, preprocessing tools, on AlmaLinux 9"
+LABEL version="1.0"
+
+# ---------- System packages ----------
+RUN dnf -y update && \
+    dnf -y install epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y groupinstall "Development Tools" && \
+    dnf -y install \
+        gcc gcc-gfortran gcc-c++ \
+        make cmake m4 perl csh tcsh git wget file which hostname rsync && \
+    dnf -y install --allowerasing curl libcurl libcurl-devel time && \
+    dnf -y install \
+        openmpi openmpi-devel \
+        jasper jasper-libs jasper-devel \
+        libpng libpng-devel \
+        zlib zlib-devel zlib-static \
+        libxml2 libxml2-devel \
+        flex libfl-static bison bison-devel bison-runtime byacc && \
+    dnf -y install python3 python3-pip python3-devel && \
+    pip3 install --upgrade pip && \
+    pip3 install numpy pyyaml && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+# ---------- Environment for building ----------
+ENV PATH="/usr/lib64/openmpi/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/lib64/openmpi/lib" \
+    CC=gcc \
+    FC=gfortran \
+    F77=gfortran \
+    F90=gfortran \
+    CXX=g++ \
+    MPICC=mpicc \
+    MPIF90=mpif90
+
+# ---------- Build HDF5 1.14.5 ----------
+ARG HDF5_VERSION=1.14.5
+ARG PREFIX=/opt/wrf-deps
+
+RUN mkdir -p /tmp/build ${PREFIX} && \
+    cd /tmp/build && \
+    wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF5_VERSION}/hdf5-${HDF5_VERSION}.tar.gz && \
+    tar xzf hdf5-${HDF5_VERSION}.tar.gz && \
+    cd hdf5-${HDF5_VERSION} && \
+    ./configure \
+        --prefix=${PREFIX} \
+        --enable-fortran \
+        --enable-shared \
+        --enable-static \
+        --enable-hl \
+        --with-zlib && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/build
+
+# ---------- Build NetCDF-C 4.9.3 ----------
+ARG NETCDF_C_VERSION=4.9.3
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib"
+
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget -q https://downloads.unidata.ucar.edu/netcdf-c/${NETCDF_C_VERSION}/netcdf-c-${NETCDF_C_VERSION}.tar.gz && \
+    tar xzf netcdf-c-${NETCDF_C_VERSION}.tar.gz && \
+    cd netcdf-c-${NETCDF_C_VERSION} && \
+    ./configure \
+        --prefix=${PREFIX} \
+        --enable-shared \
+        --enable-static \
+        --enable-netcdf-4 \
+        --disable-dap && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/build
+
+# ---------- Build NetCDF-Fortran 4.6.2 ----------
+ARG NETCDF_FORTRAN_VERSION=4.6.2
+
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    wget -q https://downloads.unidata.ucar.edu/netcdf-fortran/${NETCDF_FORTRAN_VERSION}/netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz && \
+    tar xzf netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz && \
+    cd netcdf-fortran-${NETCDF_FORTRAN_VERSION} && \
+    ./configure \
+        --prefix=${PREFIX} \
+        --enable-shared \
+        --enable-static && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/build
+
+# ---------- WRF-Chem build environment ----------
+ENV WRF_DEPS=/opt/wrf-deps \
+    NETCDF=/opt/wrf-deps \
+    NETCDF_DIR=/opt/wrf-deps \
+    HDF5=/opt/wrf-deps \
+    HDF5_DIR=/opt/wrf-deps \
+    MPI_ROOT=/usr/lib64/openmpi \
+    JASPERLIB=/usr/lib64 \
+    JASPERINC=/usr/include/jasper \
+    YACC="yacc -d" \
+    FLEX_LIB_DIR=/usr/lib64 \
+    WRF_CHEM=1 \
+    WRF_KPP=1 \
+    EM_CORE=1 \
+    WRF_EM_CORE=1 \
+    WRF_NMM_CORE=0 \
+    WRFIO_NCD_LARGE_FILE_SUPPORT=1 \
+    FCFLAGS="-fallow-argument-mismatch" \
+    FFLAGS="-fallow-argument-mismatch" \
+    F90FLAGS="-fallow-argument-mismatch"
+
+# ---------- Build WRF-Chem Preprocessing Tools ----------
+ARG WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools
+ARG PREPROC_BIN=${WRF_CHEM_PREPROC}/bin
+
+RUN cd /opt && \
+    git clone https://github.com/NCAR/WRF-Chem-Preprocessing-Tools.git ${WRF_CHEM_PREPROC} && \
+    mkdir -p ${PREPROC_BIN} && \
+    GCC10_FLAG="-fallow-argument-mismatch" && \
+    # Patch all Makefiles for GCC 10+ compatibility
+    find "${WRF_CHEM_PREPROC}" -name "Makefile" -type f | while read makefile; do \
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makefile" 2>/dev/null || true; \
+        sed -i "s/FFLAGS = -g/FFLAGS = -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true; \
+        sed -i "s/FFLAGS= -g/FFLAGS= -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true; \
+        sed -i "s/F90FLAGS = /F90FLAGS = $GCC10_FLAG /g" "$makefile" 2>/dev/null || true; \
+    done && \
+    find "${WRF_CHEM_PREPROC}" -name "make_*" -type f | while read makescript; do \
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makescript" 2>/dev/null || true; \
+        sed -i "s/gfortran -g/gfortran -g $GCC10_FLAG/g" "$makescript" 2>/dev/null || true; \
+        sed -i "s/gfortran -c/gfortran $GCC10_FLAG -c/g" "$makescript" 2>/dev/null || true; \
+    done && \
+    # Build mozbc
+    cd ${WRF_CHEM_PREPROC}/mozbc && \
+    rm -f *.o mozbc 2>/dev/null || true && \
+    if [ -f make_mozbc ]; then csh ./make_mozbc && cp mozbc ${PREPROC_BIN}/; fi && \
+    # Build anthro_emis
+    cd ${WRF_CHEM_PREPROC}/anthro_emiss/src && \
+    rm -f *.o anthro_emis 2>/dev/null || true && \
+    if [ -f make_anthro ]; then csh ./make_anthro && cp anthro_emis ${PREPROC_BIN}/; fi && \
+    # Build fire_emis
+    cd ${WRF_CHEM_PREPROC}/fire_emiss/src && \
+    rm -f *.o fire_emis 2>/dev/null || true && \
+    if [ -f make_fire_emis ]; then csh ./make_fire_emis && cp fire_emis ${PREPROC_BIN}/; fi && \
+    # Build megan_bio_emiss
+    cd ${WRF_CHEM_PREPROC}/megan_bio_emiss && \
+    rm -f *.o megan_bio_emiss 2>/dev/null || true && \
+    if [ -f make_util ]; then csh ./make_util megan_bio_emiss && cp megan_bio_emiss ${PREPROC_BIN}/; fi && \
+    # Build wesely
+    cd ${WRF_CHEM_PREPROC}/wes_coldens && \
+    rm -f *.o wesely 2>/dev/null || true && \
+    if [ -f make_util ]; then csh ./make_util wesely && cp wesely ${PREPROC_BIN}/; fi && \
+    # Build exo_coldens
+    cd ${WRF_CHEM_PREPROC}/wes_coldens && \
+    rm -f *.o exo_coldens 2>/dev/null || true && \
+    if [ -f make_util ]; then csh ./make_util exo_coldens && cp exo_coldens ${PREPROC_BIN}/; fi
+
+# ---------- Build WRF-Chem 4.7.1 ----------
+ARG WRF_VERSION=4.7.1
+ARG WRF_DIR=/opt/WRF
+ARG WPS_DIR=/opt/WPS
+ARG BIN_DIR=/wrf/bin
+
+RUN mkdir -p ${WRF_DIR} ${WPS_DIR} ${BIN_DIR} /tmp/build && \
+    echo "WRF_VERSION=${WRF_VERSION}" > ${WRF_DIR}/.version && \
+    cd /tmp/build && \
+    # IMPORTANT: Use release tarball, not "Source Code" (missing NoahMP submodule)
+    wget -q https://github.com/wrf-model/WRF/releases/download/v${WRF_VERSION}/v${WRF_VERSION}.tar.gz && \
+    tar xzf v${WRF_VERSION}.tar.gz && \
+    ln -s WRFV${WRF_VERSION} WRF && \
+    cd WRF && \
+    ./clean -a 2>/dev/null || true && \
+    # Configure WRF: option 34 = GNU dmpar, option 1 = basic nesting
+    echo -e "34\n1" | ./configure 2>&1 | tee ${WRF_DIR}/configure_wrf.log && \
+    # Patch configure.wrf for GCC 10+
+    sed -i 's/FCOPTIM.*=.*/& -fallow-argument-mismatch/' configure.wrf && \
+    sed -i 's/FCBASEOPTS_NO_G.*=.*/& -fallow-argument-mismatch/' configure.wrf && \
+    # Fix WRF 4.7.1 KPP bugs
+    sed -i 's|tuv_kpp FIRST ../../inc/|tuv_kpp FIRST ../../../../inc/|g' chem/KPP/compile_wkc && \
+    sed -i 's|char openMode\[1\] = "a"|char openMode[2] = "a"|' chem/KPP/util/wkc/tuv_kpp.c && \
+    # Compile WRF-Chem (J=1 or omit J for serial - REQUIRED for chem)
+    ./compile em_real 2>&1 | tee ${WRF_DIR}/compile_wrf.log && \
+    # Verify
+    test -f main/wrf.exe && test -f main/real.exe && \
+    # Install executables
+    cp main/*.exe ${BIN_DIR}/ && \
+    # Copy runtime files
+    cp configure.wrf ${WRF_DIR} && \
+    cp README* ${WRF_DIR} && \
+    cp LICENSE.txt ${WRF_DIR} && \
+    rsync -avL run ${WRF_DIR} --exclude "*.exe" && \
+    rsync -av doc ${WRF_DIR} && \
+    rsync -av Registry ${WRF_DIR}
+
+# ---------- Build WPS 4.6.0 ----------
+ARG WPS_VERSION=4.6.0
+
+RUN cd /tmp/build && \
+    echo "WPS_VERSION=${WPS_VERSION}" > ${WPS_DIR}/.version && \
+    wget -q https://github.com/wrf-model/WPS/archive/refs/tags/v${WPS_VERSION}.tar.gz -O wps-v${WPS_VERSION}.tar.gz && \
+    tar xzf wps-v${WPS_VERSION}.tar.gz && \
+    cd WPS-${WPS_VERSION} && \
+    # Configure WPS: option 3 = GNU dmpar
+    echo "3" | ./configure 2>&1 | tee ${WPS_DIR}/configure_wps.log && \
+    sed -i 's/FFLAGS.*=.*/& -fallow-argument-mismatch/' configure.wps && \
+    ./compile 2>&1 | tee compile_wps.log && \
+    # Verify
+    test -f geogrid/src/geogrid.exe && \
+    test -f ungrib/src/ungrib.exe && \
+    test -f metgrid/src/metgrid.exe && \
+    # Install executables
+    cp geogrid/src/geogrid.exe ${BIN_DIR}/ && \
+    cp ungrib/src/ungrib.exe ${BIN_DIR}/ && \
+    cp metgrid/src/metgrid.exe ${BIN_DIR}/ && \
+    cp link_grib.csh ${BIN_DIR}/ && \
+    rsync -avL util ${BIN_DIR}/ --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore" && \
+    # Copy runtime files
+    cp configure.wps ${WPS_DIR} && \
+    cp namelist* ${WPS_DIR} && \
+    cp README ${WPS_DIR} && \
+    rsync -av geogrid ${WPS_DIR} --exclude "*.exe" --exclude "src" --exclude "util" --exclude "CMakeLists.txt" --exclude "Makefile" && \
+    rsync -av metgrid ${WPS_DIR} --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" && \
+    rsync -av ungrib  ${WPS_DIR} --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore" && \
+    # Cleanup build artifacts
+    cd / && \
+    rm -rf /tmp/build
+
+# ==============================================================================
+# Stage 2: Runtime image (no build tools, smaller image)
+# ==============================================================================
+FROM almalinux:9
+
+LABEL maintainer="V. Weeks"
+LABEL description="WRF-Chem 4.7.1 with WPS 4.6.0, preprocessing tools, on AlmaLinux 9"
+LABEL version="1.0"
+
+# Install only runtime dependencies
+RUN dnf -y update && \
+    dnf -y install epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install \
+        openmpi openmpi-devel \
+        jasper-libs \
+        libpng \
+        zlib \
+        libxml2 \
+        libcurl \
+        csh tcsh \
+        file which hostname rsync time && \
+    dnf -y install python3 python3-pip && \
+    pip3 install numpy pyyaml && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/*
+
+# Copy built artifacts from build stage
+COPY --from=build /opt/wrf-deps /opt/wrf-deps
+COPY --from=build /opt/WRF /opt/WRF
+COPY --from=build /opt/WPS /opt/WPS
+COPY --from=build /opt/WRF-Chem-Preprocessing-Tools /opt/WRF-Chem-Preprocessing-Tools
+COPY --from=build /wrf/bin /wrf/bin
+
+# Runtime environment
+ENV LC_ALL=C \
+    LANG=C \
+    WRF_DEPS=/opt/wrf-deps \
+    HDF5=/opt/wrf-deps \
+    HDF5_DIR=/opt/wrf-deps \
+    NETCDF=/opt/wrf-deps \
+    NETCDF_DIR=/opt/wrf-deps \
+    MPI_ROOT=/usr/lib64/openmpi \
+    JASPERLIB=/usr/lib64 \
+    JASPERINC=/usr/include/jasper \
+    YACC="yacc -d" \
+    FLEX_LIB_DIR=/usr/lib64 \
+    WRF_DIR=/opt/WRF \
+    WPS_DIR=/opt/WPS \
+    WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools \
+    WRF_CHEM=1 \
+    WRF_KPP=1 \
+    EM_CORE=1 \
+    WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+ENV PATH="/wrf/bin:/opt/WRF-Chem-Preprocessing-Tools/bin:/opt/wrf-deps/bin:/usr/lib64/openmpi/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/wrf-deps/lib:/usr/lib64/openmpi/lib"
+
+WORKDIR /wrf
+
+CMD ["/bin/bash", "-c", \
+    "echo '========================================' && \
+     echo 'WRF-Chem Container - AlmaLinux 9' && \
+     echo '========================================' && \
+     echo '' && \
+     echo 'Versions:' && \
+     echo '  WRF-Chem: 4.7.1' && \
+     echo '  WPS: 4.6.0' && \
+     echo '  HDF5: 1.14.5' && \
+     echo '  NetCDF-C: 4.9.3' && \
+     echo '  NetCDF-Fortran: 4.6.2' && \
+     echo '' && \
+     echo 'WRF Executables: wrf.exe, real.exe, ndown.exe, tc.exe' && \
+     echo 'WPS Executables: geogrid.exe, ungrib.exe, metgrid.exe' && \
+     echo 'Preprocessing: mozbc, anthro_emis, fire_emis, megan_bio_emiss, wesely, exo_coldens' && \
+     echo '' && \
+     echo 'Key directories:' && \
+     echo '  WRF: /opt/WRF' && \
+     echo '  WPS: /opt/WPS' && \
+     echo '  Preprocessing: /opt/WRF-Chem-Preprocessing-Tools' && \
+     echo '  Executables: /wrf/bin' && \
+     exec /bin/bash"]

--- a/docker/wrf-chem/Dockerfile
+++ b/docker/wrf-chem/Dockerfile
@@ -180,22 +180,27 @@ RUN cd /opt && \
     if [ -f make_util ]; then csh ./make_util exo_coldens && cp exo_coldens ${PREPROC_BIN}/; fi
 
 # ---------- Build WRF-Chem 4.7.1 ----------
+# Build directly in /opt/WRF so the full build tree (including
+# external/io_netcdf/libwrfio_nf.a etc.) is available at WRF_DIR
+# for the WPS configure/link step.
 ARG WRF_VERSION=4.7.1
 ARG WRF_DIR=/opt/WRF
 ARG WPS_DIR=/opt/WPS
 ARG BIN_DIR=/wrf/bin
 
-RUN mkdir -p ${WRF_DIR} ${WPS_DIR} ${BIN_DIR} /tmp/build && \
-    echo "WRF_VERSION=${WRF_VERSION}" > ${WRF_DIR}/.version && \
+RUN mkdir -p ${WPS_DIR} ${BIN_DIR} /tmp/build && \
     cd /tmp/build && \
     # IMPORTANT: Use release tarball, not "Source Code" (missing NoahMP submodule)
     wget -q https://github.com/wrf-model/WRF/releases/download/v${WRF_VERSION}/v${WRF_VERSION}.tar.gz && \
     tar xzf v${WRF_VERSION}.tar.gz && \
-    ln -s WRFV${WRF_VERSION} WRF && \
-    cd WRF && \
+    # Move the extracted source directly to /opt/WRF
+    mv WRFV${WRF_VERSION} ${WRF_DIR} && \
+    rm -f v${WRF_VERSION}.tar.gz && \
+    cd ${WRF_DIR} && \
+    echo "WRF_VERSION=${WRF_VERSION}" > .version && \
     ./clean -a 2>/dev/null || true && \
     # Configure WRF: option 34 = GNU dmpar, option 1 = basic nesting
-    echo -e "34\n1" | ./configure 2>&1 | tee ${WRF_DIR}/configure_wrf.log && \
+    echo -e "34\n1" | ./configure 2>&1 | tee configure_wrf.log && \
     # Patch configure.wrf for GCC 10+
     sed -i 's/FCOPTIM.*=.*/& -fallow-argument-mismatch/' configure.wrf && \
     sed -i 's/FCBASEOPTS_NO_G.*=.*/& -fallow-argument-mismatch/' configure.wrf && \
@@ -203,18 +208,11 @@ RUN mkdir -p ${WRF_DIR} ${WPS_DIR} ${BIN_DIR} /tmp/build && \
     sed -i 's|tuv_kpp FIRST ../../inc/|tuv_kpp FIRST ../../../../inc/|g' chem/KPP/compile_wkc && \
     sed -i 's|char openMode\[1\] = "a"|char openMode[2] = "a"|' chem/KPP/util/wkc/tuv_kpp.c && \
     # Compile WRF-Chem (J=1 or omit J for serial - REQUIRED for chem)
-    ./compile em_real 2>&1 | tee ${WRF_DIR}/compile_wrf.log && \
+    ./compile em_real 2>&1 | tee compile_wrf.log && \
     # Verify
     test -f main/wrf.exe && test -f main/real.exe && \
-    # Install executables
-    cp main/*.exe ${BIN_DIR}/ && \
-    # Copy runtime files
-    cp configure.wrf ${WRF_DIR} && \
-    cp README* ${WRF_DIR} && \
-    cp LICENSE.txt ${WRF_DIR} && \
-    rsync -avL run ${WRF_DIR} --exclude "*.exe" && \
-    rsync -av doc ${WRF_DIR} && \
-    rsync -av Registry ${WRF_DIR}
+    # Install executables to shared bin directory
+    cp main/*.exe ${BIN_DIR}/
 
 # ---------- Build WPS 4.6.0 ----------
 ARG WPS_VERSION=4.6.0
@@ -225,6 +223,8 @@ RUN cd /tmp/build && \
     tar xzf wps-v${WPS_VERSION}.tar.gz && \
     cd WPS-${WPS_VERSION} && \
     # Configure WPS: option 3 = GNU dmpar
+    # WRF_DIR is set via ARG and visible here, so configure will find
+    # WRF build artifacts (external/io_netcdf/libwrfio_nf.a etc.) in /opt/WRF
     echo "3" | ./configure 2>&1 | tee ${WPS_DIR}/configure_wps.log && \
     sed -i 's/FFLAGS.*=.*/& -fallow-argument-mismatch/' configure.wps && \
     ./compile 2>&1 | tee compile_wps.log && \

--- a/docker/wrf-chem/README.md
+++ b/docker/wrf-chem/README.md
@@ -1,0 +1,174 @@
+# WRF-Chem Container (AlmaLinux 9)
+
+Apptainer container definition for WRF-Chem 4.7.1 with WPS 4.6.0 and all preprocessing tools, built on AlmaLinux 9.
+
+## Software Versions
+
+| Component | Version |
+|-----------|---------|
+| WRF-Chem | 4.7.1 |
+| WPS | 4.6.0 |
+| HDF5 | 1.14.5 |
+| NetCDF-C | 4.9.3 |
+| NetCDF-Fortran | 4.6.2 |
+| OpenMPI | System (AlmaLinux 9) |
+| OS | AlmaLinux 9 |
+
+### Preprocessing Tools (from [NCAR/WRF-Chem-Preprocessing-Tools](https://github.com/NCAR/WRF-Chem-Preprocessing-Tools))
+
+- **mozbc** - Boundary/initial conditions from global models (WACCM/MOZART)
+- **anthro_emis** - Anthropogenic emissions processing
+- **fire_emis** - Fire emissions (FINN) processing
+- **megan_bio_emiss** - Biogenic emissions (MEGAN) processing
+- **wesely** - Dry deposition calculations
+- **exo_coldens** - Photolysis column densities
+
+## Building
+
+### Single-layer build (recommended for distribution)
+
+```bash
+apptainer build --fakeroot wrf-chem_full_almalinux9.sif wrf-chem_full_almalinux9.def
+```
+
+Build takes approximately 1.5-2 hours and requires internet access to download source code from GitHub and Unidata.
+
+### Multi-layer build (recommended for development)
+
+Building in layers allows you to rebuild only the layer that changed (e.g., rebuild WRF without recompiling HDF5/NetCDF).
+
+```bash
+# Layer 1: OS base + HDF5 + NetCDF (~20 min)
+apptainer build --fakeroot wrf-chem_deps_almalinux9.sif wrf-chem_deps_almalinux9.def
+
+# Layer 2: Preprocessing tools (~5 min)
+apptainer build --fakeroot wrf-chem_preproc_almalinux9.sif wrf-chem_preproc_almalinux9.def
+
+# Layer 3: WRF-Chem 4.7.1 + WPS 4.6.0 (~60 min)
+apptainer build --fakeroot wrf-chem_almalinux9.sif wrf-chem_almalinux9.def
+```
+
+### Build on an HPC cluster (e.g., Derecho)
+
+When building on a cluster, use a compute node to avoid head-node resource limits. Set `APPTAINER_TMPDIR` to a filesystem with sufficient space (the default `/tmp` is often too small).
+
+```bash
+export APPTAINER_TMPDIR=/glade/derecho/scratch/$USER/apptainer_tmp
+export APPTAINER_CACHEDIR=$HOME/.apptainer/cache
+mkdir -p $APPTAINER_TMPDIR $APPTAINER_CACHEDIR
+
+apptainer build --fakeroot wrf-chem_full_almalinux9.sif wrf-chem_full_almalinux9.def
+```
+
+### Build troubleshooting
+
+If the build fails at the WRF compile step, check the compile log inside the container (sandbox mode is helpful for debugging):
+
+```bash
+# Build as a writable sandbox instead of SIF
+apptainer build --fakeroot --sandbox wrf-chem_sandbox wrf-chem_full_almalinux9.def
+
+# Shell into the sandbox to inspect
+apptainer shell --fakeroot --writable wrf-chem_sandbox
+```
+
+## Running
+
+### Interactive shell
+
+```bash
+apptainer shell wrf-chem_full_almalinux9.sif
+```
+
+### Execute a command
+
+```bash
+# Run WRF with 4 MPI processes
+apptainer exec wrf-chem_full_almalinux9.sif mpirun -np 4 wrf.exe
+
+# Run real.exe
+apptainer exec wrf-chem_full_almalinux9.sif mpirun -np 4 real.exe
+
+# Run mozbc (stdin redirection for input file)
+apptainer exec wrf-chem_full_almalinux9.sif mpirun -np 1 mozbc < mozcart_icbc.inp
+```
+
+### Running on Derecho (PBS)
+
+Bind-mount your working directories so the container can access data on GLADE. The `--pwd` flag sets the container's working directory, and `--env TMPDIR=` provides a writable location for OpenMPI session files.
+
+```bash
+module load apptainer
+
+# Configuration
+CONTAINER=/glade/work/$USER/containers/wrf-chem_full_almalinux9.sif
+WORK_DIR=/glade/work/$USER/forecast/20250115
+WRF_WORK_DIR=$WORK_DIR/wrf
+TMPDIR=$WORK_DIR/tmp
+mkdir -p $TMPDIR
+
+# Bind mounts: make GLADE paths visible inside the container
+BIND_OPTS="-B $WORK_DIR --env TMPDIR=$TMPDIR"
+
+# Define reusable apptainer exec command
+APPTAINER_EXEC="apptainer exec $BIND_OPTS --pwd $WRF_WORK_DIR $CONTAINER"
+
+# Run real.exe (preprocessing)
+$APPTAINER_EXEC mpirun -np 36 real.exe
+
+# Run mozbc (boundary conditions from WACCM - reads input file via stdin)
+$APPTAINER_EXEC mpirun -np 1 mozbc < mozcart_icbc.inp
+
+# Run WRF-Chem (main forecast)
+$APPTAINER_EXEC mpirun -np 256 wrf.exe
+```
+
+Key notes for Derecho:
+- Load the apptainer module first: `module load apptainer`
+- Use `--pwd` to set the working directory inside the container
+- Bind-mount all filesystem paths the job needs (GLADE paths are not visible inside the container by default)
+- Set `TMPDIR` via `--env` so OpenMPI can create session directories inside a writable location
+- The operational scripts (`submit_aq_fcst.bash`, `submit_daily_wrf_jobs.bash`) handle all of this automatically via PBS job submission with dependency chains
+
+## Container Internal Layout
+
+```
+/opt/
+├── wrf-deps/              # HDF5 + NetCDF libraries
+│   ├── bin/               # nc-config, nf-config, h5dump, etc.
+│   ├── include/           # Header files
+│   └── lib/               # Shared/static libraries
+├── WRF/                   # WRF source tree (run/ directory with runtime files)
+│   ├── run/               # Runtime data files (tables, coefficients)
+│   ├── Registry/
+│   └── doc/
+├── WPS/                   # WPS configuration and support files
+│   ├── geogrid/
+│   ├── metgrid/
+│   └── ungrib/
+└── WRF-Chem-Preprocessing-Tools/
+    ├── bin/               # Compiled preprocessing executables
+    ├── mozbc/
+    ├── anthro_emiss/
+    ├── fire_emiss/
+    ├── megan_bio_emiss/
+    └── wes_coldens/
+
+/wrf/bin/                  # All executables (in PATH)
+    wrf.exe, real.exe, ndown.exe, tc.exe,
+    geogrid.exe, ungrib.exe, metgrid.exe,
+    link_grib.csh, util/
+```
+
+## Known Issues
+
+### WRF 4.7.1 KPP compile bugs (patched in this def)
+
+WRF 4.7.1 has two bugs in its KPP (Kinetic PreProcessor) integration that cause the compile to fail. Both are patched automatically in the def file:
+
+1. **`compile_wkc` wrong relative path**: The `FIRST` call uses `../../inc/` but is invoked from `chem/KPP/mechanisms/$model`, requiring `../../../../inc/`.
+2. **`tuv_kpp.c` buffer overflow**: `char openMode[1] = "a"` needs `[2]` to accommodate the null terminator.
+
+### OpenMPI temporary directory
+
+OpenMPI needs a writable temporary directory for session files. When running inside the container on a cluster, the default `/tmp` may not be writable or may be shared. Always set `TMPDIR` to a writable location via `--env TMPDIR=/path/to/writable/dir`.

--- a/docker/wrf-chem/wrf-chem_almalinux9.def
+++ b/docker/wrf-chem/wrf-chem_almalinux9.def
@@ -1,0 +1,274 @@
+Bootstrap: localimage
+From: wrf-chem_preproc_almalinux9.sif
+
+%labels
+    Author V. Weeks
+    Version 1.0
+    Description WRF-Chem 4.7.1 with WPS 4.6.0 on AlmaLinux 9
+
+%post
+    # ============================================================================
+    # WRF-Chem Container Layer
+    # Builds WRF-Chem 4.7.1, WPS 4.6.0
+    # ============================================================================
+
+    set -e
+
+    # Versions
+    WRF_VERSION=4.7.1
+    WPS_VERSION=4.6.0
+
+    # Installation paths
+    WRF_DIR=/opt/WRF
+    WPS_DIR=/opt/WPS
+    BIN_DIR=/wrf/bin
+    
+    # Create directories
+    mkdir -p $WRF_DIR $WPS_DIR $BIN_DIR /tmp/build
+    echo "WRF_VERSION=$WRF_VERSION" > $WRF_DIR/.version
+    echo "WPS_VERSION=$WPS_VERSION" > $WPS_DIR/.version
+
+    # ============================================================================
+    # Environment Setup
+    # ============================================================================
+
+    # WRF-Chem specific flags
+    export WRF_CHEM=1
+    export WRF_KPP=1
+    export EM_CORE=1
+    export WRF_EM_CORE=1
+    export WRF_NMM_CORE=0
+    export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+    # GCC 10+ Fortran compatibility
+    export FCFLAGS="-fallow-argument-mismatch"
+    export FFLAGS="-fallow-argument-mismatch"
+    export F90FLAGS="-fallow-argument-mismatch"
+
+    # Compilers
+    export CC=gcc
+    export FC=gfortran
+    export F77=gfortran
+    export CXX=g++
+    export MPICC=mpicc
+    export MPIF90=mpif90
+
+    # JasPer for GRIB2 support (set explicitly for %post)
+    export JASPERLIB=/usr/lib64
+    export JASPERINC=/usr/include/jasper
+
+    # ============================================================================
+    # Download WRF 4.7.1
+    # IMPORTANT: Use release tarball, not "Source Code" (missing NoahMP submodule)
+    # The tarball extracts to directory named "WRFV4.7.1"
+    # ============================================================================
+    echo "=========================================="
+    echo "Downloading WRF ${WRF_VERSION}"
+    echo "=========================================="
+
+    cd /tmp/build
+    wget -q https://github.com/wrf-model/WRF/releases/download/v${WRF_VERSION}/v${WRF_VERSION}.tar.gz
+    tar xzf v${WRF_VERSION}.tar.gz
+
+    ln -s WRFV${WRF_VERSION} WRF
+    cd WRF
+
+    # ============================================================================
+    # Configure and Build WRF-Chem
+    # Note: KPP is built automatically by WRF when WRF_KPP=1 is set
+    # IMPORTANT: Must use J=1 (serial) to avoid race conditions
+    # ============================================================================
+    echo "=========================================="
+    echo "Configuring WRF-Chem ${WRF_VERSION}"
+    echo "=========================================="
+
+    # Clean any previous configuration
+    ./clean -a 2>/dev/null || true
+
+    # Configure WRF
+    var1=34    # option 34 = GNU dmpar for Linux x86_64
+    var2=1     # option 1 for nesting (basic)
+
+    echo -e "$var1\n$var2" | ./configure 2>&1 | tee $WRF_DIR/configure_wrf.log
+    
+    # Patch configure.wrf for GCC 10+ compatibility
+    sed -i 's/FCOPTIM.*=.*/& -fallow-argument-mismatch/' configure.wrf
+    sed -i 's/FCBASEOPTS_NO_G.*=.*/& -fallow-argument-mismatch/' configure.wrf
+
+    # Fix WRF 4.7.1 KPP tuv_kpp bugs
+    # Bug 1: compile_wkc FIRST call uses wrong relative path ../../inc/ (relative to chem/KPP)
+    #        but is called from chem/KPP/mechanisms/$model, so needs ../../../../inc/
+    # Bug 2: tuv_kpp.c has buffer overflow: char openMode[1] = "a" needs 2 bytes for null terminator
+    sed -i 's|tuv_kpp FIRST ../../inc/|tuv_kpp FIRST ../../../../inc/|g' chem/KPP/compile_wkc
+    sed -i 's|char openMode\[1\] = "a"|char openMode[2] = "a"|' chem/KPP/util/wkc/tuv_kpp.c
+
+    echo "=========================================="
+    echo "Compiling WRF-Chem (this takes a while...)"
+    echo "=========================================="
+
+    # Compile WRF-Chem with em_real core (J=1 or omit J for serial - REQUIRED for chem)
+    ./compile em_real 2>&1 | tee $WRF_DIR/compile_wrf.log
+
+    # Verify WRF build
+    if [ ! -f main/wrf.exe ] || [ ! -f main/real.exe ]; then
+        echo "ERROR: WRF-Chem build failed!"
+        echo "Check compile_wrf.log for details"
+        exit 1
+    fi
+
+    # Copy executables to bin directory
+    cp main/*.exe $BIN_DIR/
+
+    # Copy runtime files to WRF directory
+    cp configure.wrf $WRF_DIR
+    cp README* $WRF_DIR
+    cp LICENSE.txt $WRF_DIR
+    rsync -avL run $WRF_DIR --exclude "*.exe"
+    rsync -av doc $WRF_DIR
+    rsync -av Registry $WRF_DIR
+
+    echo "WRF-Chem built successfully"
+    ls -la $BIN_DIR/
+
+    # ============================================================================
+    # Download and Build WPS 4.6.0
+    # ============================================================================
+    echo "=========================================="
+    echo "Downloading WPS ${WPS_VERSION}"
+    echo "=========================================="
+
+    cd /tmp/build
+    wget -q https://github.com/wrf-model/WPS/archive/refs/tags/v${WPS_VERSION}.tar.gz -O wps-v${WPS_VERSION}.tar.gz
+    tar xzf wps-v${WPS_VERSION}.tar.gz
+    
+    cd WPS-${WPS_VERSION}
+
+    echo "=========================================="
+    echo "Configuring and Building WPS"
+    echo "=========================================="
+
+    # Configure WPS
+    var1=3    # option 3 = GNU dmpar
+    echo "$var1" | ./configure 2>&1 | tee $WPS_DIR/configure_wps.log
+
+    # Patch for GCC 10+ compatibility
+    sed -i 's/FFLAGS.*=.*/& -fallow-argument-mismatch/' configure.wps
+
+    # Compile WPS
+    ./compile 2>&1 | tee compile_wps.log
+
+    # Verify WPS build
+    if [ ! -f geogrid/src/geogrid.exe ] || [ ! -f ungrib/src/ungrib.exe ] || [ ! -f metgrid/src/metgrid.exe ]; then
+        echo "ERROR: WPS build failed!"
+        echo "Check compile_wps.log for details"
+        exit 1
+    fi
+
+    # Copy WPS executables to bin directory
+    cp geogrid/src/geogrid.exe $BIN_DIR/
+    cp ungrib/src/ungrib.exe $BIN_DIR/
+    cp metgrid/src/metgrid.exe $BIN_DIR/
+    cp link_grib.csh $BIN_DIR/
+    rsync -avL util $BIN_DIR/ --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore"
+
+    # Copy runtime files to WPS directory
+    cp configure.wps $WPS_DIR
+    cp namelist* $WPS_DIR
+    cp README $WPS_DIR
+    rsync -av geogrid $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "util" --exclude "CMakeLists.txt" --exclude "Makefile"
+    rsync -av metgrid $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile"
+    rsync -av ungrib  $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore"
+    
+    echo "WPS built successfully"
+
+    # ============================================================================
+    # Cleanup
+    # ============================================================================
+    cd /
+    rm -rf /tmp/build
+
+    # ============================================================================
+    # Final Verification
+    # ============================================================================
+    echo "=========================================="
+    echo "Final Verification"
+    echo "=========================================="
+    echo ""
+    echo "WRF Executables:"
+    ls -la $BIN_DIR/wrf.exe $BIN_DIR/real.exe $BIN_DIR/ndown.exe 2>/dev/null || echo "WARNING: Some WRF executables missing"
+    echo ""
+    echo "WPS Executables:"
+    ls -la $BIN_DIR/geogrid.exe $BIN_DIR/ungrib.exe $BIN_DIR/metgrid.exe 2>/dev/null || echo "WARNING: Some WPS executables missing"
+    echo ""
+    echo "All installed executables in $BIN_DIR:"
+    ls -la $BIN_DIR/
+
+%environment
+    export LC_ALL=C
+    export LANG=C
+
+    # WRF paths
+    export WRF_DIR=/opt/WRF
+    export WPS_DIR=/opt/WPS
+
+    # Executables PATH
+    export PATH=/wrf/bin:$PATH
+
+%runscript
+    echo "========================================"
+    echo "WRF-Chem Container - AlmaLinux 9"
+    echo "========================================"
+    echo ""
+    echo "Versions:"
+    echo "  WRF-Chem: 4.7.1"
+    echo "  WPS: 4.6.0"
+    echo "  HDF5: 1.14.5"
+    echo "  NetCDF-C: 4.9.3"
+    echo "  NetCDF-Fortran: 4.6.2"
+    echo ""
+    echo "WRF Executables: wrf.exe, real.exe, ndown.exe, tc.exe"
+    echo "WPS Executables: geogrid.exe, ungrib.exe, metgrid.exe"
+    echo "Preprocessing: mozbc, anthro_emis, fire_emis, megan_bio_emiss, wesely, exo_coldens"
+    echo ""
+    echo "Key directories:"
+    echo "  WRF: $WRF_DIR"
+    echo "  WPS: $WPS_DIR"
+    echo "  Preprocessing: $WRF_CHEM_PREPROC"
+    echo "  Executables: /wrf/bin"
+    echo ""
+    exec /bin/bash "$@"
+
+%help
+    WRF-Chem Container built on AlmaLinux 9
+
+    This container includes:
+    - WRF-Chem 4.7.1 (compiled with KPP support)
+    - WPS 4.6.0
+    - HDF5 1.14.5
+    - NetCDF-C 4.9.3
+    - NetCDF-Fortran 4.6.2
+    - OpenMPI (system package)
+
+    WRF-Chem Preprocessing Tools (from https://github.com/NCAR/WRF-Chem-Preprocessing-Tools):
+    - mozbc: Boundary/initial conditions from global models
+    - anthro_emis: Anthropogenic emissions processing
+    - fire_emis: Fire emissions (FINN) processing
+    - megan_bio_emiss: Biogenic emissions (MEGAN) processing
+    - wesely: Dry deposition calculations
+    - exo_coldens: Photolysis column densities
+
+    Build sequence:
+        # Layer 1 (base dependencies) - must exist
+        apptainer build --fakeroot wrf-chem_deps_almalinux9.sif wrf-chem_deps_almalinux9.def
+
+        # Layer 2 (WRF-Chem Preprocessing Utils) - must exist
+        apptainer build --fakeroot wrf-chem_preproc_almalinux9.sif wrf-chem_preproc_almalinux9.def
+
+        # Layer 3 (WRF-Chem) - this container
+        apptainer build --fakeroot wrf-chem_almalinux9.sif wrf-chem_almalinux9.def
+
+    Run interactively:
+        apptainer shell wrf-chem_almalinux9.sif
+
+    Run WRF:
+        apptainer exec wrf-chem_almalinux9.sif mpirun -np 4 wrf.exe

--- a/docker/wrf-chem/wrf-chem_deps_almalinux9.def
+++ b/docker/wrf-chem/wrf-chem_deps_almalinux9.def
@@ -1,0 +1,261 @@
+Bootstrap: docker
+From: almalinux:9
+
+%labels
+    Author V. Weeks
+    Version 1.0
+    Description WRF-Chem dependencies layer for AlmaLinux 9 (HDF5 1.14.5, NetCDF-C 4.9.3, NetCDF-Fortran 4.6.2)
+
+%post
+    # ============================================================================
+    # System Prep
+    # Updates and initalizes packages
+    # ============================================================================
+
+    # Full system update
+    dnf -y update
+    dnf -y clean all
+
+    # Enable EPEL and CRB (CodeReady Builder) repositories
+    dnf -y install epel-release
+    dnf config-manager --set-enabled crb
+
+    # Install Development Tools group
+    dnf -y groupinstall "Development Tools"
+
+    # Install compilers
+    dnf -y install \
+        gcc \
+	gcc-gfortran \
+	gcc-c++
+
+    # Install build tools (--allowerasing replaces curl-minimal with full curl)
+    dnf -y install --allowerasing \
+        make \
+	cmake \
+	m4 \
+	perl \
+	csh tcsh \
+	git \
+	wget \
+	curl \
+	libcurl \
+	libcurl-devel \
+	time \
+        file \
+        which \
+        hostname
+
+    # Install development libraries
+    dnf -y install \
+        openmpi \
+        openmpi-devel \
+        jasper \
+	jasper-libs \
+        jasper-devel \
+        libpng \
+        libpng-devel \
+        zlib \
+        zlib-devel \
+	zlib-static \
+        libxml2 \
+        libxml2-devel \
+        flex \
+	libfl-static \
+        bison \
+	bison-devel \
+	bison-runtime \
+        byacc
+
+    # Install Python 3 with pip and scientific packages
+    dnf -y install python3 python3-pip python3-devel
+    pip3 install --upgrade pip
+    pip3 install numpy pyyaml
+
+    # Install additional packages
+    dnf -y install rsync
+
+    # Clean up
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+    
+    # ============================================================================
+    # WRF Dependencies Layer
+    # Builds HDF5 and NetCDF libraries from source in /opt/wrf-deps
+    # ============================================================================
+
+    set -e
+
+    # Versions
+    HDF5_VERSION=1.14.5
+    NETCDF_C_VERSION=4.9.3
+    NETCDF_FORTRAN_VERSION=4.6.2
+
+    # Installation prefix
+    PREFIX=/opt/wrf-deps
+
+    # Build directory
+    BUILD_DIR=/tmp/build
+    mkdir -p $BUILD_DIR $PREFIX
+
+    # Setup environment for build
+    export PATH=/usr/lib64/openmpi/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+    export CC=gcc
+    export FC=gfortran
+    export F77=gfortran
+    export CXX=g++
+
+    # ============================================================================
+    # Build HDF5 1.14.5
+    # ============================================================================
+    echo "=========================================="
+    echo "Building HDF5 ${HDF5_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF5_VERSION}/hdf5-${HDF5_VERSION}.tar.gz
+    tar xzf hdf5-${HDF5_VERSION}.tar.gz
+    cd hdf5-${HDF5_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-fortran \
+        --enable-shared \
+        --enable-static \
+        --enable-hl \
+        --with-zlib
+
+    make -j$(nproc)
+    make install
+
+    # Update environment for NetCDF build
+    export PATH=$PREFIX/bin:$PATH
+    export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
+    export CPPFLAGS="-I$PREFIX/include"
+    export LDFLAGS="-L$PREFIX/lib"
+
+    # ============================================================================
+    # Build NetCDF-C 4.9.3
+    # ============================================================================
+    echo "=========================================="
+    echo "Building NetCDF-C ${NETCDF_C_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://downloads.unidata.ucar.edu/netcdf-c/${NETCDF_C_VERSION}/netcdf-c-${NETCDF_C_VERSION}.tar.gz
+    tar xzf netcdf-c-${NETCDF_C_VERSION}.tar.gz
+    cd netcdf-c-${NETCDF_C_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared \
+        --enable-static \
+        --enable-netcdf-4 \
+        --disable-dap
+
+    make -j$(nproc)
+    make install
+
+    # ============================================================================
+    # Build NetCDF-Fortran 4.6.2
+    # ============================================================================
+    echo "=========================================="
+    echo "Building NetCDF-Fortran ${NETCDF_FORTRAN_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://downloads.unidata.ucar.edu/netcdf-fortran/${NETCDF_FORTRAN_VERSION}/netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz
+    tar xzf netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz
+    cd netcdf-fortran-${NETCDF_FORTRAN_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared \
+        --enable-static
+
+    make -j$(nproc)
+    make install    
+
+    # ============================================================================
+    # Cleanup
+    # ============================================================================
+    rm -rf $BUILD_DIR
+    cd /
+
+    # Verify installation
+    echo "=========================================="
+    echo "Verifying installation"
+    echo "=========================================="
+    ls -la $PREFIX/lib/libhdf5* || echo "WARNING: HDF5 libraries not found"
+    ls -la $PREFIX/lib/libnetcdf* || echo "WARNING: NetCDF libraries not found"
+    $PREFIX/bin/nc-config --all || echo "WARNING: nc-config failed"
+    $PREFIX/bin/nf-config --all || echo "WARNING: nf-config failed"
+
+%environment
+    export LC_ALL=C
+    export LANG=C
+
+    # WRF Dependencies paths
+    export WRF_DEPS=/opt/wrf-deps
+    export PATH=$WRF_DEPS/bin:$PATH
+    export LD_LIBRARY_PATH=$WRF_DEPS/lib:$LD_LIBRARY_PATH
+
+    # HDF5
+    export HDF5=$WRF_DEPS
+    export HDF5_DIR=$WRF_DEPS
+
+    # NetCDF (combined C and Fortran)
+    export NETCDF=$WRF_DEPS
+    export NETCDF_DIR=$WRF_DEPS
+
+    # OpenMPI paths
+    export PATH=/usr/lib64/openmpi/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+    export MPI_ROOT=/usr/lib64/openmpi
+
+    # JasPer for GRIB2
+    export JASPERLIB=/usr/lib64
+    export JASPERINC=/usr/include/jasper
+
+    # YACC and flex (required for KPP)
+    export YACC='yacc -d'
+    export FLEX_LIB_DIR=/usr/lib64
+
+%runscript
+    echo "WRF-Chem Dependencies Container - AlmaLinux 9"
+    echo ""
+    echo "HDF5 version: 1.14.5"
+    echo "NetCDF-C version: 4.9.3"
+    echo "NetCDF-Fortran version: 4.6.2"
+    echo ""
+    echo "Environment variables set:"
+    echo "  NETCDF=$NETCDF"
+    echo "  HDF5=$HDF5"
+    echo "  YACC=$YACC"
+    echo "  FLEX_LIB_DIR=$FLEX_LIB_DIR"
+    exec /bin/bash "$@"
+
+%help
+    WRF-Chem Dependencies Container built on AlmaLinux 9
+
+    This container includes:
+    - Full system update with EPEL and CRB repositories
+
+    - Development Tools group
+    - GCC compilers (gcc, gfortran, g++)
+    - Build tools (make, cmake, m4, perl, tcsh, git, wget, curl)
+    - Development libraries (zlib, libpng, libcurl, jasper)
+    - Python 3 with pip, numpy, pyyaml   
+    
+    - HDF5 1.14.5 (with Fortran support)
+    - NetCDF-C 4.9.3
+    - NetCDF-Fortran 4.6.2
+    - OpenMPI (system package)
+    - JasPer, libpng, zlib (GRIB2 support)
+    - flex, bison, byacc (for KPP)
+
+    All libraries installed to: /opt/wrf-deps
+
+    Build with:
+        apptainer build --fakeroot wrf-chem_deps_almalinux9.sif wrf-chem_deps_almalinux9.def

--- a/docker/wrf-chem/wrf-chem_full_almalinux9.def
+++ b/docker/wrf-chem/wrf-chem_full_almalinux9.def
@@ -1,0 +1,610 @@
+Bootstrap: docker
+From: almalinux:9
+
+# Combined single-layer WRF-Chem container definition
+# Equivalent to the 3-layer build:
+#   Layer 1: wrf-chem_deps_almalinux9.def    (OS base + HDF5/NetCDF)
+#   Layer 2: wrf-chem_preproc_almalinux9.def  (WRF-Chem preprocessing tools)
+#   Layer 3: wrf-chem_almalinux9.def          (WRF-Chem 4.7.1 + WPS 4.6.0)
+#
+# Build:
+#   apptainer build --fakeroot wrf-chem_full_almalinux9.sif wrf-chem_full_almalinux9.def
+
+%labels
+    Author V. Weeks
+    Version 1.0
+    Description WRF-Chem 4.7.1 with WPS 4.6.0, preprocessing tools, on AlmaLinux 9
+
+%post
+    # ============================================================================
+    # LAYER 1: System Prep + WRF Dependencies
+    # Installs OS packages, then builds HDF5 1.14.5, NetCDF-C 4.9.3,
+    # NetCDF-Fortran 4.6.2 from source into /opt/wrf-deps
+    # ============================================================================
+
+    # Full system update
+    dnf -y update
+    dnf -y clean all
+
+    # Enable EPEL and CRB (CodeReady Builder) repositories
+    dnf -y install epel-release
+    dnf config-manager --set-enabled crb
+
+    # Install Development Tools group
+    dnf -y groupinstall "Development Tools"
+
+    # Install compilers
+    dnf -y install \
+        gcc \
+        gcc-gfortran \
+        gcc-c++
+
+    # Install build tools (--allowerasing replaces curl-minimal with full curl)
+    dnf -y install --allowerasing \
+        make \
+        cmake \
+        m4 \
+        perl \
+        csh tcsh \
+        git \
+        wget \
+        curl \
+        libcurl \
+        libcurl-devel \
+        time \
+        file \
+        which \
+        hostname
+
+    # Install development libraries
+    dnf -y install \
+        openmpi \
+        openmpi-devel \
+        jasper \
+        jasper-libs \
+        jasper-devel \
+        libpng \
+        libpng-devel \
+        zlib \
+        zlib-devel \
+        zlib-static \
+        libxml2 \
+        libxml2-devel \
+        flex \
+        libfl-static \
+        bison \
+        bison-devel \
+        bison-runtime \
+        byacc
+
+    # Install Python 3 with pip and scientific packages
+    dnf -y install python3 python3-pip python3-devel
+    pip3 install --upgrade pip
+    pip3 install numpy pyyaml
+
+    # Install additional packages
+    dnf -y install rsync
+
+    # Clean up
+    dnf clean all
+    rm -rf /var/cache/dnf/*
+
+    # ----------------------------------------
+    # Build HDF5 and NetCDF from source
+    # ----------------------------------------
+
+    set -e
+
+    # Versions
+    HDF5_VERSION=1.14.5
+    NETCDF_C_VERSION=4.9.3
+    NETCDF_FORTRAN_VERSION=4.6.2
+
+    # Installation prefix
+    PREFIX=/opt/wrf-deps
+
+    # Build directory
+    BUILD_DIR=/tmp/build
+    mkdir -p $BUILD_DIR $PREFIX
+
+    # Setup environment for build
+    export PATH=/usr/lib64/openmpi/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+    export CC=gcc
+    export FC=gfortran
+    export F77=gfortran
+    export CXX=g++
+
+    # ---- Build HDF5 1.14.5 ----
+    echo "=========================================="
+    echo "Building HDF5 ${HDF5_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF5_VERSION}/hdf5-${HDF5_VERSION}.tar.gz
+    tar xzf hdf5-${HDF5_VERSION}.tar.gz
+    cd hdf5-${HDF5_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-fortran \
+        --enable-shared \
+        --enable-static \
+        --enable-hl \
+        --with-zlib
+
+    make -j$(nproc)
+    make install
+
+    # Update environment for NetCDF build
+    export PATH=$PREFIX/bin:$PATH
+    export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
+    export CPPFLAGS="-I$PREFIX/include"
+    export LDFLAGS="-L$PREFIX/lib"
+
+    # ---- Build NetCDF-C 4.9.3 ----
+    echo "=========================================="
+    echo "Building NetCDF-C ${NETCDF_C_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://downloads.unidata.ucar.edu/netcdf-c/${NETCDF_C_VERSION}/netcdf-c-${NETCDF_C_VERSION}.tar.gz
+    tar xzf netcdf-c-${NETCDF_C_VERSION}.tar.gz
+    cd netcdf-c-${NETCDF_C_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared \
+        --enable-static \
+        --enable-netcdf-4 \
+        --disable-dap
+
+    make -j$(nproc)
+    make install
+
+    # ---- Build NetCDF-Fortran 4.6.2 ----
+    echo "=========================================="
+    echo "Building NetCDF-Fortran ${NETCDF_FORTRAN_VERSION}"
+    echo "=========================================="
+
+    cd $BUILD_DIR
+    wget -q https://downloads.unidata.ucar.edu/netcdf-fortran/${NETCDF_FORTRAN_VERSION}/netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz
+    tar xzf netcdf-fortran-${NETCDF_FORTRAN_VERSION}.tar.gz
+    cd netcdf-fortran-${NETCDF_FORTRAN_VERSION}
+
+    ./configure \
+        --prefix=$PREFIX \
+        --enable-shared \
+        --enable-static
+
+    make -j$(nproc)
+    make install
+
+    # Cleanup deps build artifacts
+    rm -rf $BUILD_DIR
+    cd /
+
+    # Verify deps installation
+    echo "=========================================="
+    echo "Verifying HDF5/NetCDF installation"
+    echo "=========================================="
+    ls -la $PREFIX/lib/libhdf5* || echo "WARNING: HDF5 libraries not found"
+    ls -la $PREFIX/lib/libnetcdf* || echo "WARNING: NetCDF libraries not found"
+    $PREFIX/bin/nc-config --all || echo "WARNING: nc-config failed"
+    $PREFIX/bin/nf-config --all || echo "WARNING: nf-config failed"
+
+    # ============================================================================
+    # Bridge: set variables that the layered build inherited via %environment
+    # In the multi-layer build, these were set in the deps layer's %environment
+    # and automatically available to subsequent layers' %post sections.
+    # ============================================================================
+    export WRF_DEPS=/opt/wrf-deps
+    export NETCDF=$WRF_DEPS
+    export NETCDF_DIR=$WRF_DEPS
+    export HDF5=$WRF_DEPS
+    export HDF5_DIR=$WRF_DEPS
+    export MPI_ROOT=/usr/lib64/openmpi
+    export JASPERLIB=/usr/lib64
+    export JASPERINC=/usr/include/jasper
+    export YACC='yacc -d'
+    export FLEX_LIB_DIR=/usr/lib64
+
+    # ============================================================================
+    # LAYER 2: WRF-Chem Preprocessing Tools
+    # Clones and builds mozbc, anthro_emis, fire_emis, megan_bio_emiss,
+    # wesely, exo_coldens from NCAR/WRF-Chem-Preprocessing-Tools
+    # ============================================================================
+
+    # Installation paths
+    WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools
+    PREPROC_BIN=$WRF_CHEM_PREPROC/bin
+
+    # WRF-Chem specific flags
+    export WRF_CHEM=1
+    export WRF_KPP=1
+    export EM_CORE=1
+    export WRF_EM_CORE=1
+    export WRF_NMM_CORE=0
+    export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+    # GCC 10+ Fortran compatibility
+    export FCFLAGS="-fallow-argument-mismatch"
+    export FFLAGS="-fallow-argument-mismatch"
+    export F90FLAGS="-fallow-argument-mismatch"
+
+    # Compilers
+    export CC=gcc
+    export FC=gfortran
+    export F77=gfortran
+    export F90=gfortran
+    export CXX=g++
+    export MPICC=mpicc
+    export MPIF90=mpif90
+
+    # ---- Clone WRF-Chem Preprocessing Tools ----
+    echo "=========================================="
+    echo "Cloning WRF-Chem Preprocessing Tools"
+    echo "=========================================="
+
+    cd /opt
+    git clone https://github.com/NCAR/WRF-Chem-Preprocessing-Tools.git $WRF_CHEM_PREPROC
+
+    mkdir -p $PREPROC_BIN
+
+    # GCC 10+ flag for legacy Fortran code
+    GCC10_FLAG="-fallow-argument-mismatch"
+
+    # ---- Patch all Makefiles for GCC 10+ compatibility ----
+    echo "Patching Makefiles for GCC 10+ compatibility..."
+
+    find "$WRF_CHEM_PREPROC" -name "Makefile" -type f | while read makefile; do
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/FFLAGS = -g/FFLAGS = -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/FFLAGS= -g/FFLAGS= -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/F90FLAGS = /F90FLAGS = $GCC10_FLAG /g" "$makefile" 2>/dev/null || true
+    done
+
+    find "$WRF_CHEM_PREPROC" -name "make_*" -type f | while read makescript; do
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makescript" 2>/dev/null || true
+        sed -i "s/gfortran -g/gfortran -g $GCC10_FLAG/g" "$makescript" 2>/dev/null || true
+        sed -i "s/gfortran -c/gfortran $GCC10_FLAG -c/g" "$makescript" 2>/dev/null || true
+    done
+
+    echo "Patching complete."
+
+    # ---- Build mozbc ----
+    echo "Building mozbc..."
+    cd $WRF_CHEM_PREPROC/mozbc
+    rm -f *.o mozbc 2>/dev/null || true
+    if [ -f make_mozbc ]; then
+        csh ./make_mozbc || echo "WARNING: mozbc build may have issues"
+        if [ -f mozbc ]; then
+            cp mozbc $PREPROC_BIN/
+            echo "SUCCESS: mozbc built and installed"
+        fi
+    fi
+
+    # ---- Build anthro_emis ----
+    echo "Building anthro_emis..."
+    cd $WRF_CHEM_PREPROC/anthro_emiss/src
+    rm -f *.o anthro_emis 2>/dev/null || true
+    if [ -f make_anthro ]; then
+        csh ./make_anthro || echo "WARNING: anthro_emis build may have issues"
+        if [ -f anthro_emis ]; then
+            cp anthro_emis $PREPROC_BIN/
+            echo "SUCCESS: anthro_emis built and installed"
+        fi
+    fi
+
+    # ---- Build fire_emis ----
+    echo "Building fire_emis..."
+    cd $WRF_CHEM_PREPROC/fire_emiss/src
+    rm -f *.o fire_emis 2>/dev/null || true
+    if [ -f make_fire_emis ]; then
+        csh ./make_fire_emis || echo "WARNING: fire_emis build may have issues"
+        if [ -f fire_emis ]; then
+            cp fire_emis $PREPROC_BIN/
+            echo "SUCCESS: fire_emis built and installed"
+        fi
+    fi
+
+    # ---- Build megan_bio_emiss ----
+    echo "Building megan_bio_emiss..."
+    cd $WRF_CHEM_PREPROC/megan_bio_emiss
+    rm -f *.o megan_bio_emiss 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util megan_bio_emiss || echo "WARNING: megan_bio_emiss build may have issues"
+        if [ -f megan_bio_emiss ]; then
+            cp megan_bio_emiss $PREPROC_BIN/
+            echo "SUCCESS: megan_bio_emiss built and installed"
+        fi
+    fi
+
+    # ---- Build wesely ----
+    echo "Building wesely..."
+    cd $WRF_CHEM_PREPROC/wes_coldens
+    rm -f *.o wesely 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util wesely || echo "WARNING: wesely build may have issues"
+        if [ -f wesely ]; then
+            cp wesely $PREPROC_BIN/
+            echo "SUCCESS: wesely built and installed"
+        fi
+    fi
+
+    # ---- Build exo_coldens ----
+    echo "Building exo_coldens..."
+    cd $WRF_CHEM_PREPROC/wes_coldens
+    rm -f *.o exo_coldens 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util exo_coldens || echo "WARNING: exo_coldens build may have issues"
+        if [ -f exo_coldens ]; then
+            cp exo_coldens $PREPROC_BIN/
+            echo "SUCCESS: exo_coldens built and installed"
+        fi
+    fi
+
+    # Verify preprocessing tools
+    echo "=========================================="
+    echo "Verifying Preprocessing Tools"
+    echo "=========================================="
+    ls -la $PREPROC_BIN/mozbc $PREPROC_BIN/anthro_emis $PREPROC_BIN/fire_emis $PREPROC_BIN/megan_bio_emiss $PREPROC_BIN/wesely $PREPROC_BIN/exo_coldens 2>/dev/null || echo "WARNING: Some preprocessing tools missing"
+
+    # ============================================================================
+    # LAYER 3: WRF-Chem 4.7.1 + WPS 4.6.0
+    # ============================================================================
+
+    # Versions
+    WRF_VERSION=4.7.1
+    WPS_VERSION=4.6.0
+
+    # Installation paths
+    WRF_DIR=/opt/WRF
+    WPS_DIR=/opt/WPS
+    BIN_DIR=/wrf/bin
+
+    # Create directories
+    mkdir -p $WRF_DIR $WPS_DIR $BIN_DIR /tmp/build
+    echo "WRF_VERSION=$WRF_VERSION" > $WRF_DIR/.version
+    echo "WPS_VERSION=$WPS_VERSION" > $WPS_DIR/.version
+
+    # ---- Download WRF 4.7.1 ----
+    # IMPORTANT: Use release tarball, not "Source Code" (missing NoahMP submodule)
+    # The tarball extracts to directory named "WRFV4.7.1"
+    echo "=========================================="
+    echo "Downloading WRF ${WRF_VERSION}"
+    echo "=========================================="
+
+    cd /tmp/build
+    wget -q https://github.com/wrf-model/WRF/releases/download/v${WRF_VERSION}/v${WRF_VERSION}.tar.gz
+    tar xzf v${WRF_VERSION}.tar.gz
+
+    ln -s WRFV${WRF_VERSION} WRF
+    cd WRF
+
+    # ---- Configure and Build WRF-Chem ----
+    # Note: KPP is built automatically by WRF when WRF_KPP=1 is set
+    # IMPORTANT: Must use J=1 (serial) to avoid race conditions
+    echo "=========================================="
+    echo "Configuring WRF-Chem ${WRF_VERSION}"
+    echo "=========================================="
+
+    # Clean any previous configuration
+    ./clean -a 2>/dev/null || true
+
+    # Configure WRF
+    var1=34    # option 34 = GNU dmpar for Linux x86_64
+    var2=1     # option 1 for nesting (basic)
+
+    echo -e "$var1\n$var2" | ./configure 2>&1 | tee $WRF_DIR/configure_wrf.log
+
+    # Patch configure.wrf for GCC 10+ compatibility
+    sed -i 's/FCOPTIM.*=.*/& -fallow-argument-mismatch/' configure.wrf
+    sed -i 's/FCBASEOPTS_NO_G.*=.*/& -fallow-argument-mismatch/' configure.wrf
+
+    # Fix WRF 4.7.1 KPP tuv_kpp bugs
+    # Bug 1: compile_wkc FIRST call uses wrong relative path ../../inc/ (relative to chem/KPP)
+    #        but is called from chem/KPP/mechanisms/$model, so needs ../../../../inc/
+    # Bug 2: tuv_kpp.c has buffer overflow: char openMode[1] = "a" needs 2 bytes for null terminator
+    sed -i 's|tuv_kpp FIRST ../../inc/|tuv_kpp FIRST ../../../../inc/|g' chem/KPP/compile_wkc
+    sed -i 's|char openMode\[1\] = "a"|char openMode[2] = "a"|' chem/KPP/util/wkc/tuv_kpp.c
+
+    echo "=========================================="
+    echo "Compiling WRF-Chem (this takes a while...)"
+    echo "=========================================="
+
+    # Compile WRF-Chem with em_real core (J=1 or omit J for serial - REQUIRED for chem)
+    ./compile em_real 2>&1 | tee $WRF_DIR/compile_wrf.log
+
+    # Verify WRF build
+    if [ ! -f main/wrf.exe ] || [ ! -f main/real.exe ]; then
+        echo "ERROR: WRF-Chem build failed!"
+        echo "Check compile_wrf.log for details"
+        exit 1
+    fi
+
+    # Copy executables to bin directory
+    cp main/*.exe $BIN_DIR/
+
+    # Copy runtime files to WRF directory
+    cp configure.wrf $WRF_DIR
+    cp README* $WRF_DIR
+    cp LICENSE.txt $WRF_DIR
+    rsync -avL run $WRF_DIR --exclude "*.exe"
+    rsync -av doc $WRF_DIR
+    rsync -av Registry $WRF_DIR
+
+    echo "WRF-Chem built successfully"
+    ls -la $BIN_DIR/
+
+    # ---- Download and Build WPS 4.6.0 ----
+    echo "=========================================="
+    echo "Downloading WPS ${WPS_VERSION}"
+    echo "=========================================="
+
+    cd /tmp/build
+    wget -q https://github.com/wrf-model/WPS/archive/refs/tags/v${WPS_VERSION}.tar.gz -O wps-v${WPS_VERSION}.tar.gz
+    tar xzf wps-v${WPS_VERSION}.tar.gz
+
+    cd WPS-${WPS_VERSION}
+
+    echo "=========================================="
+    echo "Configuring and Building WPS"
+    echo "=========================================="
+
+    # Configure WPS
+    var1=3    # option 3 = GNU dmpar
+    echo "$var1" | ./configure 2>&1 | tee $WPS_DIR/configure_wps.log
+
+    # Patch for GCC 10+ compatibility
+    sed -i 's/FFLAGS.*=.*/& -fallow-argument-mismatch/' configure.wps
+
+    # Compile WPS
+    ./compile 2>&1 | tee compile_wps.log
+
+    # Verify WPS build
+    if [ ! -f geogrid/src/geogrid.exe ] || [ ! -f ungrib/src/ungrib.exe ] || [ ! -f metgrid/src/metgrid.exe ]; then
+        echo "ERROR: WPS build failed!"
+        echo "Check compile_wps.log for details"
+        exit 1
+    fi
+
+    # Copy WPS executables to bin directory
+    cp geogrid/src/geogrid.exe $BIN_DIR/
+    cp ungrib/src/ungrib.exe $BIN_DIR/
+    cp metgrid/src/metgrid.exe $BIN_DIR/
+    cp link_grib.csh $BIN_DIR/
+    rsync -avL util $BIN_DIR/ --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore"
+
+    # Copy runtime files to WPS directory
+    cp configure.wps $WPS_DIR
+    cp namelist* $WPS_DIR
+    cp README $WPS_DIR
+    rsync -av geogrid $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "util" --exclude "CMakeLists.txt" --exclude "Makefile"
+    rsync -av metgrid $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile"
+    rsync -av ungrib  $WPS_DIR --exclude "*.exe" --exclude "src" --exclude "CMakeLists.txt" --exclude "Makefile" --exclude ".gitignore"
+
+    echo "WPS built successfully"
+
+    # ============================================================================
+    # Final Cleanup
+    # ============================================================================
+    cd /
+    rm -rf /tmp/build
+
+    # ============================================================================
+    # Final Verification
+    # ============================================================================
+    echo "=========================================="
+    echo "Final Verification"
+    echo "=========================================="
+    echo ""
+    echo "WRF Executables:"
+    ls -la $BIN_DIR/wrf.exe $BIN_DIR/real.exe $BIN_DIR/ndown.exe 2>/dev/null || echo "WARNING: Some WRF executables missing"
+    echo ""
+    echo "WPS Executables:"
+    ls -la $BIN_DIR/geogrid.exe $BIN_DIR/ungrib.exe $BIN_DIR/metgrid.exe 2>/dev/null || echo "WARNING: Some WPS executables missing"
+    echo ""
+    echo "Preprocessing Tools:"
+    ls -la $PREPROC_BIN/mozbc $PREPROC_BIN/anthro_emis $PREPROC_BIN/fire_emis $PREPROC_BIN/megan_bio_emiss $PREPROC_BIN/wesely $PREPROC_BIN/exo_coldens 2>/dev/null || echo "WARNING: Some preprocessing tools missing"
+    echo ""
+    echo "All installed executables in $BIN_DIR:"
+    ls -la $BIN_DIR/
+
+%environment
+    export LC_ALL=C
+    export LANG=C
+
+    # WRF Dependencies paths
+    export WRF_DEPS=/opt/wrf-deps
+    export PATH=$WRF_DEPS/bin:$PATH
+    export LD_LIBRARY_PATH=$WRF_DEPS/lib:$LD_LIBRARY_PATH
+
+    # HDF5
+    export HDF5=$WRF_DEPS
+    export HDF5_DIR=$WRF_DEPS
+
+    # NetCDF (combined C and Fortran)
+    export NETCDF=$WRF_DEPS
+    export NETCDF_DIR=$WRF_DEPS
+
+    # OpenMPI paths
+    export PATH=/usr/lib64/openmpi/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+    export MPI_ROOT=/usr/lib64/openmpi
+
+    # JasPer for GRIB2
+    export JASPERLIB=/usr/lib64
+    export JASPERINC=/usr/include/jasper
+
+    # YACC and flex (required for KPP)
+    export YACC='yacc -d'
+    export FLEX_LIB_DIR=/usr/lib64
+
+    # WRF paths
+    export WRF_DIR=/opt/WRF
+    export WPS_DIR=/opt/WPS
+
+    # WRF-Chem Preprocessing Tools
+    export WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools
+
+    # WRF-Chem flags (for any recompilation)
+    export WRF_CHEM=1
+    export WRF_KPP=1
+    export EM_CORE=1
+    export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+    # Executables PATH
+    export PATH=/wrf/bin:$WRF_CHEM_PREPROC/bin:$PATH
+
+%runscript
+    echo "========================================"
+    echo "WRF-Chem Container - AlmaLinux 9"
+    echo "========================================"
+    echo ""
+    echo "Versions:"
+    echo "  WRF-Chem: 4.7.1"
+    echo "  WPS: 4.6.0"
+    echo "  HDF5: 1.14.5"
+    echo "  NetCDF-C: 4.9.3"
+    echo "  NetCDF-Fortran: 4.6.2"
+    echo ""
+    echo "WRF Executables: wrf.exe, real.exe, ndown.exe, tc.exe"
+    echo "WPS Executables: geogrid.exe, ungrib.exe, metgrid.exe"
+    echo "Preprocessing: mozbc, anthro_emis, fire_emis, megan_bio_emiss, wesely, exo_coldens"
+    echo ""
+    echo "Key directories:"
+    echo "  WRF: $WRF_DIR"
+    echo "  WPS: $WPS_DIR"
+    echo "  Preprocessing: $WRF_CHEM_PREPROC"
+    echo "  Executables: /wrf/bin"
+    echo ""
+    exec /bin/bash "$@"
+
+%help
+    WRF-Chem Container built on AlmaLinux 9 (single-layer build)
+
+    This container includes:
+    - WRF-Chem 4.7.1 (compiled with KPP support)
+    - WPS 4.6.0
+    - HDF5 1.14.5
+    - NetCDF-C 4.9.3
+    - NetCDF-Fortran 4.6.2
+    - OpenMPI (system package)
+
+    WRF-Chem Preprocessing Tools (from https://github.com/NCAR/WRF-Chem-Preprocessing-Tools):
+    - mozbc: Boundary/initial conditions from global models
+    - anthro_emis: Anthropogenic emissions processing
+    - fire_emis: Fire emissions (FINN) processing
+    - megan_bio_emiss: Biogenic emissions (MEGAN) processing
+    - wesely: Dry deposition calculations
+    - exo_coldens: Photolysis column densities
+
+    Build:
+        apptainer build --fakeroot wrf-chem_full_almalinux9.sif wrf-chem_full_almalinux9.def
+
+    Run interactively:
+        apptainer shell wrf-chem_full_almalinux9.sif
+
+    Run WRF:
+        apptainer exec wrf-chem_full_almalinux9.sif mpirun -np 4 wrf.exe

--- a/docker/wrf-chem/wrf-chem_preproc_almalinux9.def
+++ b/docker/wrf-chem/wrf-chem_preproc_almalinux9.def
@@ -1,0 +1,232 @@
+Bootstrap: localimage
+From: wrf-chem_deps_almalinux9.sif
+
+%labels
+    Author V. Weeks
+    Version 1.0
+    Description WRF-Chem preprocessing tools on AlmaLinux 9
+
+%post
+    # ============================================================================
+    # WRF-Chem Preprocessing Utils Container Layer
+    # Builds WRF-Chem Preprocessing Utils
+    # ============================================================================
+
+    # Installation paths
+    WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools
+    BIN_DIR=$WRF_CHEM_PREPROC/bin
+    
+    # ============================================================================
+    # Environment Setup
+    # ============================================================================
+
+    # these are already set in bootstrap container
+    # export WRF_DEPS=/opt/wrf-deps
+    # export PATH=$WRF_DEPS/bin:/usr/lib64/openmpi/bin:$PATH
+    # export LD_LIBRARY_PATH=$WRF_DEPS/lib:/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+
+    ## NetCDF and HDF5
+    # export NETCDF=$WRF_DEPS
+    # export NETCDF_DIR=$WRF_DEPS
+    # export HDF5=$WRF_DEPS
+
+    ## JasPer for GRIB2
+    # export JASPERLIB=/usr/lib64
+    # export JASPERINC=/usr/include/jasper
+
+    # WRF-Chem specific flags
+    export WRF_CHEM=1
+    export WRF_KPP=1
+    export EM_CORE=1
+    export WRF_EM_CORE=1
+    export WRF_NMM_CORE=0
+    export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+    # GCC 10+ Fortran compatibility
+    export FCFLAGS="-fallow-argument-mismatch"
+    export FFLAGS="-fallow-argument-mismatch"
+    export F90FLAGS="-fallow-argument-mismatch"
+
+    # Compilers
+    export CC=gcc
+    export FC=gfortran
+    export F77=gfortran
+    export F90=gfortran
+    export CXX=g++
+    export MPICC=mpicc
+    export MPIF90=mpif90
+
+    set -e
+
+    # ============================================================================
+    # Clone and Build WRF-Chem Preprocessing Tools
+    # ============================================================================
+    echo "=========================================="
+    echo "Cloning WRF-Chem Preprocessing Tools"
+    echo "=========================================="
+
+    cd /opt
+    git clone https://github.com/NCAR/WRF-Chem-Preprocessing-Tools.git $WRF_CHEM_PREPROC
+
+    # Create directories for preprocessing tools
+    mkdir -p $BIN_DIR
+
+    # GCC 10+ flag for legacy Fortran code
+    GCC10_FLAG="-fallow-argument-mismatch"
+
+    # ============================================================================
+    # Patch all Makefiles for GCC 10+ compatibility
+    # ============================================================================
+    echo "Patching Makefiles for GCC 10+ compatibility..."
+
+    find "$WRF_CHEM_PREPROC" -name "Makefile" -type f | while read makefile; do
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/FFLAGS = -g/FFLAGS = -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/FFLAGS= -g/FFLAGS= -g $GCC10_FLAG/g" "$makefile" 2>/dev/null || true
+        sed -i "s/F90FLAGS = /F90FLAGS = $GCC10_FLAG /g" "$makefile" 2>/dev/null || true
+    done
+
+    find "$WRF_CHEM_PREPROC" -name "make_*" -type f | while read makescript; do
+        sed -i "s/-ffree-line-length-none/-ffree-line-length-none $GCC10_FLAG/g" "$makescript" 2>/dev/null || true
+        sed -i "s/gfortran -g/gfortran -g $GCC10_FLAG/g" "$makescript" 2>/dev/null || true
+        sed -i "s/gfortran -c/gfortran $GCC10_FLAG -c/g" "$makescript" 2>/dev/null || true
+    done
+
+    echo "Patching complete."
+
+    # ============================================================================
+    # Build MOZBC
+    # ============================================================================
+    echo "Building mozbc..."
+    cd $WRF_CHEM_PREPROC/mozbc
+    rm -f *.o mozbc 2>/dev/null || true
+    if [ -f make_mozbc ]; then
+        csh ./make_mozbc || echo "WARNING: mozbc build may have issues"
+        if [ -f mozbc ]; then
+            cp mozbc $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: mozbc built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Build anthro_emis
+    # ============================================================================
+    echo "Building anthro_emis..."
+    cd $WRF_CHEM_PREPROC/anthro_emiss/src
+    rm -f *.o anthro_emis 2>/dev/null || true
+    if [ -f make_anthro ]; then
+        csh ./make_anthro || echo "WARNING: anthro_emis build may have issues"
+        if [ -f anthro_emis ]; then
+            cp anthro_emis $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: anthro_emis built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Build fire_emis
+    # ============================================================================
+    echo "Building fire_emis..."
+    cd $WRF_CHEM_PREPROC/fire_emiss/src
+    rm -f *.o fire_emis 2>/dev/null || true
+    if [ -f make_fire_emis ]; then
+        csh ./make_fire_emis || echo "WARNING: fire_emis build may have issues"
+        if [ -f fire_emis ]; then
+            cp fire_emis $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: fire_emis built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Build megan_bio_emiss
+    # ============================================================================
+    echo "Building megan_bio_emiss..."
+    cd $WRF_CHEM_PREPROC/megan_bio_emiss
+    rm -f *.o megan_bio_emiss 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util megan_bio_emiss || echo "WARNING: megan_bio_emiss build may have issues"
+        if [ -f megan_bio_emiss ]; then
+            cp megan_bio_emiss $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: megan_bio_emiss built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Build wesely
+    # ============================================================================
+    echo "Building wesely..."
+    cd $WRF_CHEM_PREPROC/wes_coldens
+    rm -f *.o wesely 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util wesely || echo "WARNING: wesely build may have issues"
+        if [ -f wesely ]; then
+            cp wesely $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: wesely built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Build exo_coldens
+    # ============================================================================
+    echo "Building exo_coldens..."
+    cd $WRF_CHEM_PREPROC/wes_coldens
+    rm -f *.o exo_coldens 2>/dev/null || true
+    if [ -f make_util ]; then
+        csh ./make_util exo_coldens || echo "WARNING: exo_coldens build may have issues"
+        if [ -f exo_coldens ]; then
+            cp exo_coldens $WRF_CHEM_PREPROC/bin/
+            echo "SUCCESS: exo_coldens built and installed"
+        fi
+    fi
+
+    # ============================================================================
+    # Final Verification
+    # ============================================================================
+    echo "=========================================="
+    echo "Final Verification"
+    echo "=========================================="
+    echo ""
+    echo "Preprocessing Tools:"
+    ls -la $BIN_DIR/mozbc $BIN_DIR/anthro_emis $BIN_DIR/fire_emis $BIN_DIR/megan_bio_emiss $BIN_DIR/wesely $BIN_DIR/exo_coldens 2>/dev/null || echo "WARNING: Some preprocessing tools missing"
+    echo ""
+    echo "All installed executables in $BIN_DIR:"
+    ls -la $BIN_DIR/
+
+%environment
+    export LC_ALL=C
+    export LANG=C
+
+    # WRF-Chem Preprocessing Tools
+    export WRF_CHEM_PREPROC=/opt/WRF-Chem-Preprocessing-Tools
+
+    # Executables PATH
+    export PATH=$WRF_CHEM_PREPROC/bin:$PATH
+
+%runscript
+    echo "========================================"
+    echo "WRF-Chem Preprocessing Utils Container - AlmaLinux 9"
+    echo "========================================"
+    echo ""
+    echo "Preprocessing Utils: mozbc, anthro_emis, fire_emis, megan_bio_emiss, wesely, exo_coldens"
+    echo ""
+    echo "Key directories:"
+    echo "  Preprocessing: $WRF_CHEM_PREPROC/bin"
+    echo ""
+    exec /bin/bash "$@"
+
+%help
+    WRF-Chem Preprocessing Utils Container built on AlmaLinux 9
+
+    This container includes the WRF-Chem Preprocessing Tools (from https://github.com/NCAR/WRF-Chem-Preprocessing-Tools):
+    - mozbc: Boundary/initial conditions from global models
+    - anthro_emis: Anthropogenic emissions processing
+    - fire_emis: Fire emissions (FINN) processing
+    - megan_bio_emiss: Biogenic emissions (MEGAN) processing
+    - wesely: Dry deposition calculations
+    - exo_coldens: Photolysis column densities
+
+    Build sequence:
+        # Layer 1 (base dependencies) - must exist
+        apptainer build --fakeroot wrf-chem_deps_almalinux9.sif wrf-chem_deps_almalinux9.def
+
+        # Layer 2 (WRF-Chem Preprocessing Utils) - this container
+        apptainer build --fakeroot wrf-chem_preproc_almalinux9.sif wrf-chem_preproc_almalinux9.def


### PR DESCRIPTION
## Summary
- Adds Apptainer `.def` files for building WRF-Chem 4.7.1 / WPS 4.6.0 containers on AlmaLinux 9, supporting both single-layer (distribution) and multi-layer (development) builds
- Includes all WRF-Chem preprocessing tools (mozbc, anthro_emis, fire_emis, megan_bio_emiss, wesely, exo_coldens)
- Adds Dockerfile equivalent of the full single-layer Apptainer build using multi-stage Docker build
- Adds README with build instructions, HPC (Derecho) usage examples, container layout, and known issues (including WRF 4.7.1 KPP compile bug patches)
- Adds GitHub Actions workflow (`.github/workflows/build-wrf-chem-docker.yml`) that builds the Docker image on `ubuntu-latest` and publishes it to GHCR on merges to `main` and on `wrf-chem-v*` tags. PRs that touch `docker/wrf-chem/**` build-only to validate the Dockerfile without publishing.

Closes #76

## Docker build workflow

Because macOS (Apple Silicon) can't realistically produce an `amd64` WRF-Chem image locally, the Docker build is delegated to GitHub Actions:

- **Runner:** `ubuntu-latest` (4 vCPU / 16 GB RAM / ~14 GB free disk).
- **Disk prep:** an inline cleanup step removes preinstalled Android SDK, .NET, Haskell, CodeQL, etc. to reclaim ~30 GB — the full build otherwise exceeds the default free space.
- **Build driver:** `docker buildx` with a `docker-container` builder (required for advanced cache backends).
- **Caching:** registry-backed — layer cache is stored as a sibling OCI tag `ghcr.io/ncar/i-wrf/wrf-chem:buildcache` (`type=registry,mode=max`). First build is cold; subsequent builds skip cached stages.
- **Auth:** uses the built-in `GITHUB_TOKEN` with `packages: write`; no separate secrets to manage.
- **Tag derivation** (inline shell, since `docker/metadata-action` is blocked by NCAR's third-party-action policy):
  - push to `main` → `:main`, `:latest`, `:sha-<short>`
  - tag `wrf-chem-vX.Y.Z` → `:X.Y.Z`, `:latest`
  - `workflow_dispatch` → `:manual-<short>`
  - PR (build-only, not pushed) → `:pr-<num>`
- **Policy compliance:** uses only `actions/checkout@v4` (GitHub-owned). All other steps are raw shell / `docker` CLI to satisfy NCAR's "actions must be from a repository owned by NCAR or created by GitHub" restriction.
- **Result:** first cold build of the full multi-stage image (AlmaLinux 9 → Dev Tools + NetCDF/HDF5 → WRF-Chem 4.7.1 + WPS 4.6.0 + preprocessing tools) completes well under the 6-hour job limit.

## Test plan
- [x] Build multi-layer containers (deps → preproc → wrf-chem) and verify each layer succeeds
- [x] Verify WRF-Chem executables are present and functional inside container (`wrf.exe`, `real.exe`, preprocessing tools)
- [x] Test running on Derecho with bind mounts and MPI
- [x] Build full single-layer Apptainer container: `apptainer build --fakeroot wrf-chem_full_almalinux9.sif wrf-chem_full_almalinux9.def`
- [x] Build Docker image via GitHub Actions workflow on PR (build-only, no push)
- [ ] Post-merge: confirm GitHub Actions run on `main` pushes image to `ghcr.io/ncar/i-wrf/wrf-chem:main` / `:latest` and seeds `:buildcache`
- [ ] Tag `wrf-chem-v4.7.1` to publish a versioned image `ghcr.io/ncar/i-wrf/wrf-chem:4.7.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)